### PR TITLE
Fix: inconsistent use of caml_strdup

### DIFF
--- a/src/lib/ssh_ml.m
+++ b/src/lib/ssh_ml.m
@@ -59,7 +59,7 @@
 		[self.parent_handler receive_ssh_output_result:pulled];
 		break;
 	}
-	free(result);
+	caml_stat_free(result);
 }
 
 @end


### PR DESCRIPTION
This is the same kind of a potential issue that I found in [ocaml-brotli](https://github.com/fxfactorial/ocaml-brotli/pull/1): 

> Hello. I'm doing a large-scale study of C stub sources on OPAM.
> 
> Your library makes use of the undocumented `caml_strdup` function, which currently returns a block that can be passed to `free` from the C standard library. In future, the implementation of this function [may change](https://github.com/ocaml/ocaml/pull/71), making it incompatible with `free` and breaking the code that abused the old undocumented semantics.
> 
> Regardless of whether the change of semantics will happen or not, being consistent about such matters should be considered good style.
